### PR TITLE
Fix parse-date unit tests

### DIFF
--- a/tests/parse-date-test.js
+++ b/tests/parse-date-test.js
@@ -1,39 +1,40 @@
 jest.autoMockOff();
 
 var parseDate = require('../src/utils/parse-date');
+var sampleTimestamp = new Date('01/31/1990 00:00:00').getTime();
 
 describe('parse-date', function () {
   it('parses MM/DD/YYYY formatted dates', function () {
-    expect(parseDate('01/31/1990')).toBe(633751200000);
+    expect(parseDate('01/31/1990')).toBe(sampleTimestamp);
   });
 
   it('parses MM/DD/YYYY HH:MM:SS formatted dates', function () {
-    expect(parseDate('01/31/1990 00:00:00')).toBe(633751200000);
+    expect(parseDate('01/31/1990 00:00:00')).toBe(sampleTimestamp);
   });
 
   it('parses YYYY-MM-DD formatted dates', function () {
-    expect(parseDate('1990-01-31')).toBe(633751200000);
+    expect(parseDate('1990-01-31')).toBe(sampleTimestamp);
   });
 
   it('parses YYYY-MM-DD HH:MM:SS formatted dates', function () {
-    expect(parseDate('1990-01-31 00:00:00')).toBe(633751200000);
+    expect(parseDate('1990-01-31 00:00:00')).toBe(sampleTimestamp);
   });
 
   it('parses date strings with no set time', function () {
-    expect(parseDate('Jan 31, 1990')).toBe(633751200000);
-    expect(parseDate('Wed, Jan 31, 1990')).toBe(633751200000);
-    expect(parseDate('Wednesday, Jan 31, 1990')).toBe(633751200000);
-    expect(parseDate('January 31, 1990')).toBe(633751200000);
-    expect(parseDate('Wed, January 31, 1990')).toBe(633751200000);
-    expect(parseDate('Wednesday, January 31, 1990')).toBe(633751200000);
+    expect(parseDate('Jan 31, 1990')).toBe(sampleTimestamp);
+    expect(parseDate('Wed, Jan 31, 1990')).toBe(sampleTimestamp);
+    expect(parseDate('Wednesday, Jan 31, 1990')).toBe(sampleTimestamp);
+    expect(parseDate('January 31, 1990')).toBe(sampleTimestamp);
+    expect(parseDate('Wed, January 31, 1990')).toBe(sampleTimestamp);
+    expect(parseDate('Wednesday, January 31, 1990')).toBe(sampleTimestamp);
   });
 
   it('parses strings with a set date and time', function () {
-    expect(parseDate('Jan 31, 1990 00:00:00')).toBe(633751200000);
-    expect(parseDate('Wed, Jan 31, 1990 00:00:00')).toBe(633751200000);
-    expect(parseDate('Wednesday, Jan 31, 1990 00:00:00')).toBe(633751200000);
-    expect(parseDate('January 31, 1990 00:00:00')).toBe(633751200000);
-    expect(parseDate('Wed, January 31, 1990 00:00:00')).toBe(633751200000);
-    expect(parseDate('Wednesday, January 31, 1990 00:00:00')).toBe(633751200000);
+    expect(parseDate('Jan 31, 1990 00:00:00')).toBe(sampleTimestamp);
+    expect(parseDate('Wed, Jan 31, 1990 00:00:00')).toBe(sampleTimestamp);
+    expect(parseDate('Wednesday, Jan 31, 1990 00:00:00')).toBe(sampleTimestamp);
+    expect(parseDate('January 31, 1990 00:00:00')).toBe(sampleTimestamp);
+    expect(parseDate('Wed, January 31, 1990 00:00:00')).toBe(sampleTimestamp);
+    expect(parseDate('Wednesday, January 31, 1990 00:00:00')).toBe(sampleTimestamp);
   });
 });


### PR DESCRIPTION
Right now unit tests for the `parse-date` module were based off a particular timezone (UTC-2) since timestamps were hardcoded, causing tests to fail if they got run on a different timezone (also on Travis). This commit should fix this issue.
